### PR TITLE
Fix file path case in algorithm fetch

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -89,7 +89,7 @@ const Main: React.FC = () => {
     const fetchAlgorithmContent = async () => {
       try {
         const algorithmFolder = selectedAlgorithm.replace(/\s+/g, "");
-        const baseName = selectedAlgorithm.replace(/\s+/g, "").toLowerCase();
+        const baseName = selectedAlgorithm.replace(/\s+/g, "");
 
         const extensions: Record<LanguageName, string> = {
           Java: "java",


### PR DESCRIPTION
## Summary
- fix incorrect casing when building algorithm file paths

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875987b39e0832cbccf7db485dbb309